### PR TITLE
管理者の商品一覧に商品登録に戻るリンクを表示した。

### DIFF
--- a/app/controllers/admin/cuisines_controller.rb
+++ b/app/controllers/admin/cuisines_controller.rb
@@ -1,4 +1,5 @@
 class Admin::CuisinesController < ApplicationController
+  before_action :require_permission
   layout "admin"
   
   def new

--- a/app/controllers/admin/topics_controller.rb
+++ b/app/controllers/admin/topics_controller.rb
@@ -1,6 +1,6 @@
 class Admin::TopicsController < ApplicationController
-  layout "admin"
   before_action :require_permission
+  layout "admin"
   
   def index
   end

--- a/app/views/admin/cuisines/index.html.erb
+++ b/app/views/admin/cuisines/index.html.erb
@@ -1,3 +1,6 @@
+<div class="product_registration_tag">
+  <%= link_to "商品登録", "/admin/cuisines/new" %>  
+</div>
 <div id="product_list">
   <% @cuisines.each do |cuisine| %>
     <div class="card">


### PR DESCRIPTION
# 管理者の商品一覧ページ
* 管理者の商品一覧のページに商品登録の画面に戻るページのリンクの表示をした。

# admin/ cuisines_controller 
* admin/cuisines_controller に一般ユーザーがURL を指定しても入って来れないようにした。
